### PR TITLE
Handle non-numeric values in currency formatter

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -6,6 +6,14 @@ const founders = [
   { id: "ahmed", name: "Ahmed Sherif" },
 ];
 
-const EGP = (v) => `${v.toFixed(2)} EGP`;
+// Format a number as an Egyptian pound currency string. The original
+// implementation assumed that `v` was always a valid number and would throw
+// when called with `undefined`, `null` or any non‑numeric value. That scenario
+// can surface when calculating totals from optional data. To prevent runtime
+// crashes, coerce the input to a number and guard against `NaN`.
+const EGP = (v) => {
+  const value = Number(v);
+  return Number.isFinite(value) ? `${value.toFixed(2)} EGP` : "0.00 EGP";
+};
 
 // ... (rest of the code omitted for brevity, but keep the full user code here with corrected template literals)


### PR DESCRIPTION
## Summary
- guard against non-numeric inputs in `EGP` formatter to prevent runtime crashes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5ee03cc4832391edfde7f942f40d